### PR TITLE
Edit tests

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,6 +1,9 @@
 import pytest
 import milmapcon as mmc
 
+LAT_TOLERANCE = 0.001
+LON_TOLERANCE = 0.001
+
 @pytest.mark.parametrize('zone,grid_square,lat_test,lon_test', [
     ('british_cassini', 'wL350780', 52.21665, -0.68511),
     ('irish_cassini', 'iN250800', 53.76897, -7.62082),
@@ -19,8 +22,20 @@ def test_six_digit_precision(zone, grid_square, lat_test, lon_test):
     lat_delta = abs(lat_test - lat)
     lon_delta = abs(lon_test - lon)
 
-    assert lat_delta <= 0.001, f'Latitude conversion out of spec: Latitude delta for {zone} -> {grid_square} = {lat_delta}'
-    assert lon_delta <= 0.001, f'Longitude conversion out of spec: Longitude delta for {zone} -> {grid_square} = {lon_delta}'
+    errors = []
+    try:
+        assert lat_delta <= LAT_TOLERANCE
+    except AssertionError:
+        msg = f'Latitude error > {LAT_TOLERANCE}: Latitude delta for {zone} -> {grid_square} = {lat_delta}'
+        errors.append(msg)
+    try:
+        assert lon_delta <= LON_TOLERANCE
+    except AssertionError:
+        msg = f'Longitude error > {LON_TOLERANCE}: Longitude delta for {zone} -> {grid_square} = {lon_delta}'
+        errors.append(msg)
+    
+    assert not errors, f'Failed for the following cases:\n {"\n".join(errors)}'
+
 
 @pytest.mark.parametrize('zone,grid_square,lat_test,lon_test',[
     ('british_cassini', 'wL4586', 52.28782, -0.53772),
@@ -40,5 +55,16 @@ def test_four_digit_precision(zone, grid_square, lat_test, lon_test):
     lat_delta = abs(lat_test - lat)
     lon_delta = abs(lon_test - lon)
 
-    assert lat_delta <= 0.001, f'Latitude conversion out of spec: Latitude delta for {zone} -> {grid_square} = {lat_delta}'
-    assert lon_delta <= 0.001, f'Longitude conversion out of spec: Longitude delta for {zone} -> {grid_square} = {lon_delta}'
+    errors = []
+    try:
+        assert lat_delta <= LAT_TOLERANCE
+    except AssertionError:
+        msg = f'Latitude error > {LAT_TOLERANCE}: Latitude delta for {zone} -> {grid_square} = {lat_delta}'
+        errors.append(msg)
+    try:
+        assert lon_delta <= LON_TOLERANCE
+    except AssertionError:
+        msg = f'Longitude error > {LON_TOLERANCE}: Longitude delta for {zone} -> {grid_square} = {lon_delta}'
+        errors.append(msg)
+    
+    assert not errors, f'Failed for the following cases:\n {"\n".join(errors)}'

--- a/tests/test_en_from_grid.py
+++ b/tests/test_en_from_grid.py
@@ -16,5 +16,4 @@ def test_en_from_grid(label, zone, grid, x, y, E_test, N_test):
 
     E, N = mmc.EN_from_grid(zone, grid, x, y)
 
-    assert E == E_test, f'Easting for {label} test is incorrect'
-    assert N == N_test, f'Northing for {label} test is incorrect'
+    assert (E,N) == (E_test, N_test), f'Easting or Northing is incorrect for {label} test'

--- a/tests/test_get_origin.py
+++ b/tests/test_get_origin.py
@@ -14,5 +14,5 @@ def test_get_origin(label, zone,grid, x0_test, y0_test):
     '''Test that get_origin returns a valid x0, y0 for a good origin and None otherwise'''
 
     x0, y0 = mmc.get_origin(zone, grid)
-    assert x0 == x0_test, f'x0 value is incorrect for {label} test'
-    assert y0 == y0_test, f'y0 value is incorrect for {label} test'
+
+    assert (x0, y0) == (x0_test, y0_test), f'x0 or y0 value incorrect for {label} test'

--- a/tests/test_parse_gridsquare.py
+++ b/tests/test_parse_gridsquare.py
@@ -13,7 +13,4 @@ def test_parse_gridsquare(label, grid_reference, grid_letters_test,clean_grid_te
 
     grid_letters, clean_grid, x_m, y_m = mmc.parse_gridsquare(grid_reference)
 
-    assert grid_letters == grid_letters_test, f'Grid letters do not match for {grid_reference} in {label} test'
-    assert clean_grid == clean_grid_test, f'Clean grid was not extractedfor {grid_reference} in {label} test'
-    assert x_m == x_m_test, f'x_m values do not match for {grid_reference} in {label} test'
-    assert y_m == y_m_test, f'y_m values do not match for {grid_reference} in {label} test'
+    assert (grid_letters, clean_grid, x_m, y_m) == (grid_letters_test, clean_grid_test, x_m_test, y_m_test), f'Test failed for {grid_reference} in {label} test'


### PR DESCRIPTION
Fixed error in previous test suite where multiple assert statements (as written) would not all run. Refactored the tests to include either equality testing between tuples or try/except blocks which collect failing test in a list, running the main assertion against whether the list of errors is empty or not.